### PR TITLE
fix(css-kube): rectify broken close button style

### DIFF
--- a/sass/css/kube/_custom.scss
+++ b/sass/css/kube/_custom.scss
@@ -58,3 +58,7 @@
     padding-right: 10px;
   }
 }
+
+.close {
+  cursor: pointer;
+}

--- a/sass/css/kube/_kube.scss
+++ b/sass/css/kube/_kube.scss
@@ -1721,7 +1721,8 @@ button:hover,
   vertical-align: middle;
   text-align: center;
   font-size: 12px;
-  opacity: .6; }
+  opacity: .6;
+  cursor: pointer; }
   .close:hover {
     opacity: 1; }
   .close.small {


### PR DESCRIPTION
修改关闭按钮的鼠标手势，使其更像一个可点击的按钮。